### PR TITLE
Fix build issue and improve movement logic

### DIFF
--- a/Emergentia/Agent.cs
+++ b/Emergentia/Agent.cs
@@ -58,7 +58,8 @@ public class Agent
 
     private void GetLeastCrowdedMove(out int newX, out int newY, int width, int height, List<Agent> allAgents)
     {
-        int bestX = X, bestY = Y, minNeighbors = int.MaxValue;
+        int currentNeighbors = CountNeighbors(allAgents);
+        int bestX = X, bestY = Y, minNeighbors = currentNeighbors;
 
         for (int dx = -1; dx <= 1; dx++)
         {

--- a/Emergentia/Emergentia.csproj
+++ b/Emergentia/Emergentia.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>


### PR DESCRIPTION
## Summary
- target .NET 8.0 so the solution builds with available SDK
- improve `GetLeastCrowdedMove` so agents only move when a less crowded location is found

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_687e4ec7dc288327877a9e2b1e6fa6c5