### PR TITLE
Add temp grid for simultaneous agent updates

### DIFF
--- a/Emergentia/Agent.cs
+++ b/Emergentia/Agent.cs
@@ -40,6 +40,31 @@ public class Agent
         }
     }
 
+    public (int, int) ComputeMove(char[,] grid, int width, int height, List<Agent> allAgents)
+    {
+        int neighbors = CountNeighbors(allAgents);
+
+        int newX = X;
+        int newY = Y;
+
+        if (neighbors == 0)
+        {
+            GetRandomMove(out newX, out newY, width, height);
+        }
+        else if (neighbors >= 3)
+        {
+            GetLeastCrowdedMove(out newX, out newY, width, height, allAgents);
+        }
+
+        if (grid[newX, newY] != '\0')
+        {
+            newX = X;
+            newY = Y;
+        }
+
+        return (newX, newY);
+    }
+
     private int CountNeighbors(List<Agent> allAgents)
     {
         return allAgents.Count(a =>

--- a/Emergentia/Program.cs
+++ b/Emergentia/Program.cs
@@ -40,16 +40,36 @@ internal class Program
 
     private static void UpdateAgents()
     {
-        // Clear grid
+        var tempGrid = new char[Width, Height];
+        var snapshot = Agents.Select(a => new Agent(a.X, a.Y)).ToList();
+        var newPositions = new (int X, int Y)[Agents.Count];
+
+        for (int i = 0; i < Agents.Count; i++)
+        {
+            var agent = Agents[i];
+            var (nx, ny) = agent.ComputeMove(Grid, Width, Height, snapshot);
+
+            if (tempGrid[nx, ny] == '\0')
+            {
+                newPositions[i] = (nx, ny);
+                tempGrid[nx, ny] = AgentChar;
+            }
+            else
+            {
+                newPositions[i] = (agent.X, agent.Y);
+                tempGrid[agent.X, agent.Y] = AgentChar;
+            }
+        }
+
+        for (int i = 0; i < Agents.Count; i++)
+        {
+            Agents[i].X = newPositions[i].X;
+            Agents[i].Y = newPositions[i].Y;
+        }
+
         for (int x = 0; x < Width; x++)
         for (int y = 0; y < Height; y++)
-            Grid[x, y] = '\0';
-
-        foreach (var agent in Agents)
-        {
-            agent.Update(Grid, Width, Height, Agents);
-            Grid[agent.X, agent.Y] = AgentChar;
-        }
+            Grid[x, y] = tempGrid[x, y];
     }
 
     private static void DrawGrid()


### PR DESCRIPTION
## Summary
- use a temporary grid in `UpdateAgents`
- compute each agent's move without altering others using `ComputeMove`
- apply all new positions once all moves are decided

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e50907ec08327a68f3ecf5caaf4fe